### PR TITLE
Update edit.js

### DIFF
--- a/interface/super/rules/www/js/edit.js
+++ b/interface/super/rules/www/js/edit.js
@@ -4,6 +4,27 @@
 var rule_edit = function( args ) {
 
     var fn_work = function() {
+       $(".form-control").each( function() {
+            $(this).attr("placeholder","Enter a number");
+            $(this).attr("pattern","[0-9]+");
+            $(this).on('input', function() {
+                if (this.value.match(/[^0-9]/)) {
+                    var currentValue = this.value;
+                    var newValue = currentValue.replace(/[^0-9]/g, '');
+                    this.value = newValue;
+                    this.setCustomValidity('Please enter a valid integer.');
+                } else {
+                    this.setCustomValidity('');
+                }
+                this.reportValidity();
+            });
+            $(this).on('keydown', function(event) {
+                if (event.key === 'e' || event.key === '.' || event.key === '-') {
+                    event.preventDefault();
+                }
+            });
+        });
+
         // setup required
         $(".req").each( function() {
             var txt = $(this).text();
@@ -15,7 +36,6 @@ var rule_edit = function( args ) {
             $("#required_msg").show();
         }
     }
-
     var fn_validate = function() {
         String.prototype.trim = function() {
             return this.replace(/^\s+|\s+$/g,"");


### PR DESCRIPTION

Fixes #5 

In this commit, I have addressed an issue in the edit.js file where the CDR Reminder Intervals lacked a placeholder for input elements, resulting in users entering alphabetical values. To enhance user experience and prevent this issue, I have added the placeholder "Enter a number" to guide users in entering only numeric values. This modification ensures a smoother data input process by blocking the alphabetical values and avoids potential errors when saving the page or values.


