### PR TITLE
Update demographics.php

### DIFF
--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1346,22 +1346,23 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                         $dispatchResult = $ed->dispatch(new CardRenderEvent('vital_sign'), CardRenderEvent::EVENT_HANDLE);
                         // vitals expand collapse widget
                         // check to see if any vitals exist
-                        $existVitals = sqlQuery("SELECT * FROM form_vitals WHERE pid=?", array($pid));
-                        $widgetAuth = ($existVitals) ? true : false;
+                            $existVitals = sqlQuery("SELECT * FROM form_vitals WHERE pid=?", array($pid));
+                            $formId = sqlQuery("SELECT MAX(id) as max_id FROM form_vitals WHERE pid=?", array($pid));
+                            $widgetAuth = ($existVitals) ? true : false;
 
-                        $id = "vitals_ps_expand";
-                        $viewArgs = [
-                            'title' => xl('Vitals'),
-                            'id' => $id,
-                            'initiallyCollapsed' => (getUserSetting($id) == 0) ? true : false,
-                            'btnLabel' => 'Trend',
-                            'btnLink' => "../encounter/trend_form.php?formname=vitals&context=dashboard",
-                            'linkMethod' => 'html',
-                            'bodyClass' => 'collapse show',
-                            'auth' => $widgetAuth,
-                            'prependedInjection' => $dispatchResult->getPrependedInjection(),
-                            'appendedInjection' => $dispatchResult->getAppendedInjection(),
-                        ];
+                            $id = "vitals_ps_expand";
+                            $viewArgs = [
+                                'title' => xl('Vitals'),
+                                'id' => $id,
+                                'initiallyCollapsed' => (getUserSetting($id) == 0) ? true : false,
+                                'btnLabel' => 'Edit',
+                                'btnLink' => "../encounter/view_form.php?formname=vitals&id=" . $formId['max_id'],
+                                'linkMethod' => 'html',
+                                'bodyClass' => 'collapse show',
+                                'auth' => $widgetAuth,
+                                'prependedInjection' => $dispatchResult->getPrependedInjection(),
+                                'appendedInjection' => $dispatchResult->getAppendedInjection(),
+                            ];
                         if (!in_array('card_vitals', $hiddenCards)) {
                             echo $twig->getTwig()->render('patient/card/loader.html.twig', $viewArgs);
                         }


### PR DESCRIPTION
<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7

#### Short description of what this resolves:
In the OpenEMR dashboard, under the patient’s Vitals tab, the blue pencil icon is intended to direct users to the Vitals page for easy access and updates. However, clicking this button currently redirects users to the Demographics page instead. The link has been modified to correctly redirect to the Vitals page as originally intended.
![Screenshot (122)](https://github.com/user-attachments/assets/22e401de-714e-441f-8942-25c10c5a40ae)
![image](https://github.com/user-attachments/assets/95db83de-acda-49f8-a1f1-db91f79c216b)
