### PR TITLE
Update demographics.php

### DIFF
--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1360,21 +1360,24 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                         $dispatchResult = $ed->dispatch(new CardRenderEvent('vital_sign'), CardRenderEvent::EVENT_HANDLE);
                         // vitals expand collapse widget
                         // check to see if any vitals exist
-                        $existVitals = sqlQuery("SELECT * FROM form_vitals WHERE pid=?", array($pid));
-                        $widgetAuth = ($existVitals) ? true : false;
+                            $existVitals = sqlQuery("SELECT * FROM form_vitals WHERE pid=?", array($pid));
+                            $formId = sqlQuery("SELECT MAX(id) as max_id FROM form_vitals WHERE pid=?", array($pid));
+                            $widgetAuth = ($existVitals) ? true : false;
 
-                        $id = "vitals_ps_expand";
-                        $viewArgs = [
-                            'title' => xl('Vitals'),
-                            'id' => $id,
-                            'initiallyCollapsed' => (getUserSetting($id) == 0) ? true : false,
-                            'btnLabel' => 'Edit',
-                            'btnLink' => '../encounter/view_form.php?formname=vitals',
-                            'bodyClass' => 'collapse show',
-                            'auth' => $widgetAuth,
-                            'prependedInjection' => $dispatchResult->getPrependedInjection(),
-                            'appendedInjection' => $dispatchResult->getAppendedInjection(),
-                        ];
+                            $id = "vitals_ps_expand";
+                            $viewArgs = [
+                                'title' => xl('Vitals'),
+                                'id' => $id,
+                                'initiallyCollapsed' => (getUserSetting($id) == 0) ? true : false,
+                                'btnLabel' => 'Edit',
+                                'btnLink' => "../encounter/view_form.php?formname=vitals&id=" . $formId['max_id'],
+                                'linkMethod' => 'html',
+                                'bodyClass' => 'collapse show',
+                                'auth' => $widgetAuth,
+                                'prependedInjection' => $dispatchResult->getPrependedInjection(),
+                                'appendedInjection' => $dispatchResult->getAppendedInjection(),
+                            ];
+
                         echo $twig->getTwig()->render('patient/card/loader.html.twig', $viewArgs);
                     endif; // end vitals
 


### PR DESCRIPTION

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7 

#### Short description of what this resolves:
In the OpenEMR dashboard, under the patient’s Vitals tab, the blue pencil icon is intended to direct users to the Vitals page for easy access and updates. However, clicking this button currently redirects users to the Demographics page instead. The link has been modified to correctly redirect to the Vitals page as originally intended.
![Screenshot (122)](https://github.com/user-attachments/assets/6b2bc359-9800-4d1f-b863-dbd666b08946)
![Screenshot (123)](https://github.com/user-attachments/assets/0298875e-7e0e-4172-afb9-aee0cd345c4f)

