### PR TITLE
Update user_data_template.php

### DIFF
--- a/interface/main/tabs/templates/user_data_template.php
+++ b/interface/main/tabs/templates/user_data_template.php
@@ -20,6 +20,7 @@
     <!-- ko with: user -->
         <div id="username" class="appMenu ml-3">
                 <div class='menuLabel dropdown' id="username" title="<?php echo xla('Current user') ?>" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <span data-bind="text:fname"></span>&nbsp;<span data-bind="text:lname"></span>
                     <span class="fa-stack">
                         <i class="far text-muted fa-circle fa-2x fa-stack-2x"></i>
                         <i class="fa text-muted fa-user fa-lg fa-stack-1x" aria-hidden="true" id="user_icon"></i>


### PR DESCRIPTION
<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #33 

#### Short description of what this resolves:
This pull request resolves the issue of the username not being visible in the header, which previously required users to click on the profile icon to view it. 
![image](https://github.com/user-attachments/assets/acec3de9-bc76-4a0d-acce-485b7e1fd7ef)

#### Changes proposed in this pull request:
Added the username display beside the profile icon in the header for immediate visibility.
