### PR TITLE
SSN verification in patient search

### DIFF
--- a/oemr-selenium/clinical_notes_search.py
+++ b/oemr-selenium/clinical_notes_search.py
@@ -1,0 +1,171 @@
+import pytest
+import os
+from selenium import webdriver
+from selenium.common import NoSuchElementException, NoAlertPresentException
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.alert import Alert
+from webdriver_manager.chrome import ChromeDriverManager
+from test_utils import *
+import re
+
+class TestWebsite_vitals:
+    @pytest.fixture(autouse=True)
+    def browser_setup_and_teardown(self):
+        options = Options()
+        if os.environ.get('HEADLESS', 'false').lower() == 'true':
+            options.add_argument("--headless")
+            options.add_argument("--no-sandbox")
+            options.add_argument("--disable-dev-shm-usage")
+
+        self.browser = webdriver.Chrome(options=options)
+        self.browser.maximize_window()
+        self.browser.implicitly_wait(10)
+        yield
+        self.browser.close()
+        self.browser.quit()
+
+    @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
+    def test_vitals_is_present_on_patient_dashboard(self, config):
+        success = login(self.browser, config.username, config.password, config.url, config.server_name)
+        assert success, f"Login failed for server {config.url}"
+        wait_for_page_load(self.browser)
+
+        search_box = self.browser.find_element(By.ID, 'anySearchBox')
+        search_box.clear()
+        search_box.send_keys('a')
+        self.browser.find_element(By.ID, 'search_globals').click()
+        wait_for_page_load(self.browser)
+
+        WebDriverWait(self.browser, 10).until(EC.frame_to_be_available_and_switch_to_it((By.NAME, "fin")))
+        wait_for_page_load(self.browser)
+
+        first_patient = self.browser.find_elements(By.CSS_SELECTOR, 'tr td a')[0]
+        first_patient.click()
+        self.browser.switch_to.default_content()
+        wait_for_page_load(self.browser)
+
+        iframe = self.browser.find_element(By.CSS_SELECTOR, '#framesDisplay > div > iframe')
+        self.browser.switch_to.frame(iframe)
+        wait_for_page_load(self.browser)
+
+        container_div = self.browser.find_element(By.ID, 'container_div')
+        main_divs = container_div.find_elements(By.CLASS_NAME, 'main.mb-5')
+        for div in main_divs:
+            try:
+                class_row = div.find_element(By.CLASS_NAME, 'row')
+                card_sections = class_row.find_elements(By.CSS_SELECTOR, 'section.card.mb-2')
+                if card_sections:
+                    last_card_section = card_sections[-1]
+                    vitals_expand_div = last_card_section.find_element(By.ID, 'vitals_ps_expand')
+                    link_to_click = vitals_expand_div.find_element(By.PARTIAL_LINK_TEXT,
+                                                                   'Click here to view and graph all vitals.')
+                    link_to_click.click()
+                    wait_for_page_load(self.browser)
+                    try:
+                        alert = Alert(self.browser)
+                        alert.accept()
+                    except NoAlertPresentException:
+                        pass
+                    break
+            except NoSuchElementException:
+                pass
+
+    @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
+    def test_vitals_validation_in_encounters(self, config):
+        success = login(self.browser, config.username, config.password, config.url, config.server_name)
+        assert success, f"Login failed for server {config.url}"
+        wait_for_page_load(self.browser)
+
+        search_box = WebDriverWait(self.browser, 10).until(
+            EC.presence_of_element_located((By.ID, "anySearchBox"))
+        )
+        search_box.clear()
+        search_box.send_keys('a')
+        self.browser.find_element(By.ID, 'search_globals').click()
+        wait_for_page_load(self.browser)
+
+        WebDriverWait(self.browser, 10).until(EC.frame_to_be_available_and_switch_to_it((By.NAME, "fin")))
+        wait_for_page_load(self.browser)
+
+        first_patient = WebDriverWait(self.browser, 10).until(
+            EC.presence_of_all_elements_located((By.CSS_SELECTOR, 'tr td a'))
+        )[0]
+        first_patient.click()
+        self.browser.switch_to.default_content()
+        wait_for_page_load(self.browser)
+
+        try:
+            pastEncounters = WebDriverWait(self.browser, 5).until(
+                EC.element_to_be_clickable((By.ID, "pastEncounters"))
+            )
+            pastEncounters.click()
+        except Exception as e:
+            print(f"'Past Encounters' was blocked, checking for popups...")
+
+            try:
+                WebDriverWait(self.browser, 3).until(EC.presence_of_element_located((By.ID, "modalframe")))
+                self.browser.switch_to.frame("modalframe")
+
+                close_button = WebDriverWait(self.browser, 5).until(
+                    EC.element_to_be_clickable((By.ID, "close"))
+                )
+                close_button.click()
+                self.browser.switch_to.default_content()
+                wait_for_page_load(self.browser)
+
+                pastEncounters = WebDriverWait(self.browser, 5).until(
+                    EC.element_to_be_clickable((By.ID, "pastEncounters"))
+                )
+                pastEncounters.click()
+            except (NoSuchElementException, TimeoutException):
+                pass
+
+        wait_for_page_load(self.browser)
+
+        latestEncounter = self.browser.find_element(By.XPATH, '//*[@id="attendantData"]/div/div[2]/div[1]/div/ul/li[1]/a[1]')
+        latestEncounter.click()
+        wait_for_page_load(self.browser)
+
+        firstIframe = self.browser.find_element(By.XPATH, '//*[@id="framesDisplay"]/div[3]/iframe')
+        self.browser.switch_to.frame(firstIframe)
+        wait_for_page_load(self.browser)
+
+        secondIframe = self.browser.find_element(By.XPATH, '//*[@id="enctabs-1"]/iframe')
+        self.browser.switch_to.frame(secondIframe)
+        wait_for_page_load(self.browser)
+
+        clinical_notes = self.browser.find_elements(By.XPATH, "//div[starts-with(@id, 'clinical_notes~')]")
+        wait_for_page_load(self.browser)
+
+        try:
+            clinical_notes_divs = self.browser.find_elements(By.XPATH, "//div[starts-with(@id, 'clinical_notes~')]")
+            assert clinical_notes_divs, "Clinical Notes section not found (no div with id starting with 'clinical_notes~')."
+
+            clinical_notes_found_with_data = False
+
+            for div in clinical_notes_divs:
+                try:
+                    section_element = div.find_element(By.XPATH, ".//section[contains(@class, 'mb-3')]")
+                    section_text = section_element.text.strip()
+
+                    print(f"Clinical Notes content preview: {section_text[:100]}")
+
+                    if section_text:
+                        clinical_notes_found_with_data = True
+                        break
+                except NoSuchElementException:
+                    continue
+
+            assert clinical_notes_found_with_data, "Clinical Notes section found, but no content present in <section class='mb-3'>."
+
+            print("Clinical Notes are present and contain data.")
+
+        except AssertionError as ae:
+            pytest.fail(str(ae))
+        except Exception as e:
+            pytest.fail(f"Error while checking Clinical Notes: {str(e)}")
+
+

--- a/oemr-selenium/ssn_search.py
+++ b/oemr-selenium/ssn_search.py
@@ -1,0 +1,55 @@
+import pytest
+import os
+from selenium import webdriver
+from selenium.webdriver import Keys
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from webdriver_manager.chrome import ChromeDriverManager
+from test_utils import *
+import re
+
+class TestWebsite_patient_search:
+    @pytest.fixture(autouse=True)
+    def browser_setup_and_teardown(self):
+        options = Options()
+        if os.environ.get('HEADLESS', 'false').lower() == 'true':
+            options.add_argument("--headless")
+            options.add_argument("--no-sandbox")
+            options.add_argument("--disable-dev-shm-usage")
+
+        self.browser = webdriver.Chrome(options=options)
+        self.browser.implicitly_wait(10)
+        yield
+        self.browser.quit()
+
+    @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
+    def test_search_found_patient_using_search_bar(self, config):
+        success = login(self.browser, config.username, config.password, config.url, config.server_name)
+        assert success, f"Login failed for server {config.url}"
+        wait_for_page_load(self.browser)
+
+        search_box = self.browser.find_element(By.ID, 'anySearchBox')
+        search_box.clear()
+        search_box.send_keys('100')
+        self.browser.find_element(By.ID, 'search_globals').click()
+        wait_for_page_load(self.browser)
+
+        WebDriverWait(self.browser, 10).until(EC.frame_to_be_available_and_switch_to_it((By.NAME, "fin")))
+        wait_for_page_load(self.browser)
+
+        results_text = self.browser.find_element(By.ID, "pt_table_info").text
+
+        match = re.search(r'Showing (\d+)', results_text)
+        assert match, "Could not find 'Showing X' in results text!"
+
+        assert int(match.group(1)) > 0, f"Search returned zero results: {results_text}"
+
+        first_row = self.browser.find_element(By.CSS_SELECTOR, "#pt_table tbody tr")
+        ssn_pattern = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")  # SSN format: 123-45-6789
+
+        if ssn_pattern.search(first_row.text):
+            print("SSN found in the first row.")
+        else:
+            assert False, "SSN not found in the first row of the search results!"


### PR DESCRIPTION
Fixes #51 

#### Short description of what this resolves:
- Implemented automated test to verify that SSNs are correctly displayed in 
  the first row of patient search results in OpenEMR.
- Updated `test_search_found_patient_using_search_bar` to include an SSN 
  validation step using regex pattern `\b\d{3}-\d{2}-\d{4}\b`.
- Ensured the test fails with an appropriate message if SSN is missing.
