### PR TITLE
Fixed CDR rule and vitals tests: added scrolling and interactable checks

### DIFF
--- a/oemr-selenium/cdr_rule.py
+++ b/oemr-selenium/cdr_rule.py
@@ -1,5 +1,5 @@
 # Complete cdr_rule.py with Full-Page Load Check Added
-
+import time
 import pytest
 import os
 from selenium import webdriver
@@ -12,6 +12,12 @@ from webdriver_manager.chrome import ChromeDriverManager
 from test_utils import *
 
 class TestWebsite_cdr_rule:
+    def scroll_and_wait_for_size(self, element):
+            self.browser.execute_script("arguments[0].scrollIntoView(true);", element)
+            WebDriverWait(self.browser, 5).until(
+                lambda d: element.size['height'] > 0 and element.size['width'] > 0
+            )
+            time.sleep(0.5)
     @pytest.fixture(autouse=True)
     def browser_setup_and_teardown(self):
         options = Options()
@@ -33,15 +39,30 @@ class TestWebsite_cdr_rule:
         assert success, f"Login failed for server {config.url}"
         wait_for_page_load(self.browser)
 
-        adminMenu = self.browser.find_element(By.XPATH, '//*[@id="mainMenu"]/div/div[10]/div/div')
-        actions = ActionChains(self.browser)
-        actions.move_to_element(adminMenu).perform()
-        wait_for_page_load(self.browser)
+        adminMenu = WebDriverWait(self.browser, 3).until(
+            EC.element_to_be_clickable((By.XPATH, '//*[@id="mainMenu"]/div/div[10]/div/div'))
+        )
+        self.scroll_and_wait_for_size(adminMenu)
+        adminMenu.click()
+        time.sleep(0.5)
 
-        practiceMenu = self.browser.find_element(By.XPATH, '//*[@id="mainMenu"]/div/div[10]/div/ul/li[4]/div/div')
-        actions.move_to_element(practiceMenu).perform()
-        wait_for_page_load(self.browser)
+        practiceMenu = WebDriverWait(self.browser, 1).until(
+            EC.element_to_be_clickable((By.XPATH, '//*[@id="mainMenu"]/div/div[10]/div/ul/li[4]/div/div'))
+        )
+        self.scroll_and_wait_for_size(practiceMenu)
+        practiceMenu.click()
+        time.sleep(0.5)
 
-        rules = self.browser.find_element(By.XPATH, '//*[@id="mainMenu"]/div/div[10]/div/ul/li[4]/div/ul/li[2]/div')
+        rules = WebDriverWait(self.browser, 1).until(
+            EC.element_to_be_clickable((By.XPATH, '//*[@id="mainMenu"]/div/div[10]/div/ul/li[4]/div/ul/li[2]/div'))
+        )
+        self.scroll_and_wait_for_size(rules)
         rules.click()
         wait_for_page_load(self.browser)
+
+        WebDriverWait(self.browser, 3).until(
+            EC.frame_to_be_available_and_switch_to_it((By.CSS_SELECTOR, "#framesDisplay iframe"))
+        )
+
+
+

--- a/oemr-selenium/vitals.py
+++ b/oemr-selenium/vitals.py
@@ -1,3 +1,4 @@
+import time
 import pytest
 import os
 from selenium import webdriver
@@ -138,6 +139,8 @@ class TestWebsite_vitals:
         wait_for_page_load(self.browser)
 
         clinicalTab = self.browser.find_element(By.XPATH, '//*[@id="category_Clinical"]')
+        self.browser.execute_script("arguments[0].scrollIntoView(true);", clinicalTab)
+        time.sleep(1)
         clinicalTab.click()
         wait_for_page_load(self.browser)
 


### PR DESCRIPTION
This PR updates cdr_rule.py and vitals.py Selenium tests to:

- Scroll into view for menu elements (Admin → Practice → Rules)
- Ensure elements are interactable using element_to_be_clickable
- Add brief waits for rendering to avoid ElementNotInteractableException

Tested successfully across OpenEMR demo servers. Improves test stability under headless Chrome.
