### PR TITLE
Fix headless mode viewport issues in Selenium tests

### DIFF
--- a/oemr-selenium/active_medication_check.py
+++ b/oemr-selenium/active_medication_check.py
@@ -18,6 +18,7 @@ class TestWebsite_vitals:
         if os.environ.get('HEADLESS', 'false').lower() == 'true':
             options.add_argument("--headless")
             options.add_argument("--no-sandbox")
+            options.add_argument('--window-size=1920,1080')
             options.add_argument("--disable-dev-shm-usage")
 
         self.browser = webdriver.Chrome(options=options)

--- a/oemr-selenium/bp_value_check.py
+++ b/oemr-selenium/bp_value_check.py
@@ -14,6 +14,7 @@ class TestBPValues:
         if os.environ.get("HEADLESS", "false").lower() == "true":
             options.add_argument("--headless")
             options.add_argument("--no-sandbox")
+            options.add_argument('--window-size=1920,1080')
             options.add_argument("--disable-dev-shm-usage")
         self.browser = webdriver.Chrome(options=options)
         self.browser.maximize_window()

--- a/oemr-selenium/cdr_rule.py
+++ b/oemr-selenium/cdr_rule.py
@@ -1,5 +1,3 @@
-# Complete cdr_rule.py with Full-Page Load Check Added
-import time
 import pytest
 import os
 from selenium import webdriver
@@ -12,18 +10,13 @@ from webdriver_manager.chrome import ChromeDriverManager
 from test_utils import *
 
 class TestWebsite_cdr_rule:
-    def scroll_and_wait_for_size(self, element):
-            self.browser.execute_script("arguments[0].scrollIntoView(true);", element)
-            WebDriverWait(self.browser, 5).until(
-                lambda d: element.size['height'] > 0 and element.size['width'] > 0
-            )
-            time.sleep(0.5)
     @pytest.fixture(autouse=True)
     def browser_setup_and_teardown(self):
         options = Options()
         if os.environ.get('HEADLESS', 'false').lower() == 'true':
             options.add_argument("--headless")
             options.add_argument("--no-sandbox")
+            options.add_argument('--window-size=1920,1080')
             options.add_argument("--disable-dev-shm-usage")
 
         self.browser = webdriver.Chrome(options=options)
@@ -39,30 +32,15 @@ class TestWebsite_cdr_rule:
         assert success, f"Login failed for server {config.url}"
         wait_for_page_load(self.browser)
 
-        adminMenu = WebDriverWait(self.browser, 3).until(
-            EC.element_to_be_clickable((By.XPATH, '//*[@id="mainMenu"]/div/div[10]/div/div'))
-        )
-        self.scroll_and_wait_for_size(adminMenu)
-        adminMenu.click()
-        time.sleep(0.5)
-
-        practiceMenu = WebDriverWait(self.browser, 1).until(
-            EC.element_to_be_clickable((By.XPATH, '//*[@id="mainMenu"]/div/div[10]/div/ul/li[4]/div/div'))
-        )
-        self.scroll_and_wait_for_size(practiceMenu)
-        practiceMenu.click()
-        time.sleep(0.5)
-
-        rules = WebDriverWait(self.browser, 1).until(
-            EC.element_to_be_clickable((By.XPATH, '//*[@id="mainMenu"]/div/div[10]/div/ul/li[4]/div/ul/li[2]/div'))
-        )
-        self.scroll_and_wait_for_size(rules)
-        rules.click()
+        adminMenu = self.browser.find_element(By.XPATH, '//*[@id="mainMenu"]/div/div[10]/div/div')
+        actions = ActionChains(self.browser)
+        actions.move_to_element(adminMenu).perform()
         wait_for_page_load(self.browser)
 
-        WebDriverWait(self.browser, 3).until(
-            EC.frame_to_be_available_and_switch_to_it((By.CSS_SELECTOR, "#framesDisplay iframe"))
-        )
+        practiceMenu = self.browser.find_element(By.XPATH, '//*[@id="mainMenu"]/div/div[10]/div/ul/li[4]/div/div')
+        actions.move_to_element(practiceMenu).perform()
+        wait_for_page_load(self.browser)
 
-
-
+        rules = self.browser.find_element(By.XPATH, '//*[@id="mainMenu"]/div/div[10]/div/ul/li[4]/div/ul/li[2]/div')
+        rules.click()
+        wait_for_page_load(self.browser)

--- a/oemr-selenium/cdr_rule.py
+++ b/oemr-selenium/cdr_rule.py
@@ -1,5 +1,5 @@
 # Complete cdr_rule.py with Full-Page Load Check Added
-
+import time
 import pytest
 import os
 from selenium import webdriver
@@ -12,6 +12,12 @@ from webdriver_manager.chrome import ChromeDriverManager
 from test_utils import *
 
 class TestWebsite_cdr_rule:
+    def scroll_and_wait_for_size(self, element):
+            self.browser.execute_script("arguments[0].scrollIntoView(true);", element)
+            WebDriverWait(self.browser, 5).until(
+                lambda d: element.size['height'] > 0 and element.size['width'] > 0
+            )
+            time.sleep(0.5)
     @pytest.fixture(autouse=True)
     def browser_setup_and_teardown(self):
         options = Options()
@@ -33,15 +39,30 @@ class TestWebsite_cdr_rule:
         assert success, f"Login failed for server {config.url}"
         wait_for_page_load(self.browser)
 
-        adminMenu = self.browser.find_element(By.XPATH, '//*[@id="mainMenu"]/div/div[10]/div/div')
-        actions = ActionChains(self.browser)
-        actions.move_to_element(adminMenu).perform()
-        wait_for_page_load(self.browser)
+        adminMenu = WebDriverWait(self.browser, 3).until(
+            EC.element_to_be_clickable((By.XPATH, '//*[@id="mainMenu"]/div/div[10]/div/div'))
+        )
+        self.scroll_and_wait_for_size(adminMenu)
+        adminMenu.click()
+        time.sleep(0.5)
 
-        practiceMenu = self.browser.find_element(By.XPATH, '//*[@id="mainMenu"]/div/div[10]/div/ul/li[4]/div/div')
-        actions.move_to_element(practiceMenu).perform()
-        wait_for_page_load(self.browser)
+        practiceMenu = WebDriverWait(self.browser, 1).until(
+            EC.element_to_be_clickable((By.XPATH, '//*[@id="mainMenu"]/div/div[10]/div/ul/li[4]/div/div'))
+        )
+        self.scroll_and_wait_for_size(practiceMenu)
+        practiceMenu.click()
+        time.sleep(0.5)
 
-        rules = self.browser.find_element(By.XPATH, '//*[@id="mainMenu"]/div/div[10]/div/ul/li[4]/div/ul/li[2]/div')
+        rules = WebDriverWait(self.browser, 1).until(
+            EC.element_to_be_clickable((By.XPATH, '//*[@id="mainMenu"]/div/div[10]/div/ul/li[4]/div/ul/li[2]/div'))
+        )
+        self.scroll_and_wait_for_size(rules)
         rules.click()
         wait_for_page_load(self.browser)
+
+        WebDriverWait(self.browser, 3).until(
+            EC.frame_to_be_available_and_switch_to_it((By.CSS_SELECTOR, "#framesDisplay iframe"))
+        )
+
+
+

--- a/oemr-selenium/clinical_notes_search.py
+++ b/oemr-selenium/clinical_notes_search.py
@@ -18,6 +18,7 @@ class TestWebsite_vitals:
         if os.environ.get('HEADLESS', 'false').lower() == 'true':
             options.add_argument("--headless")
             options.add_argument("--no-sandbox")
+            options.add_argument('--window-size=1920,1080')
             options.add_argument("--disable-dev-shm-usage")
 
         self.browser = webdriver.Chrome(options=options)

--- a/oemr-selenium/code_check.py
+++ b/oemr-selenium/code_check.py
@@ -16,6 +16,7 @@ class TestWebsite_cdr_code_check:
         if os.environ.get('HEADLESS', 'false').lower() == 'true':
             options.add_argument("--headless")
             options.add_argument("--no-sandbox")
+            options.add_argument('--window-size=1920,1080')
             options.add_argument("--disable-dev-shm-usage")
 
         self.browser = webdriver.Chrome(options=options)

--- a/oemr-selenium/facilities_check.py
+++ b/oemr-selenium/facilities_check.py
@@ -14,6 +14,7 @@ class TestFacilityList:
         if os.environ.get("HEADLESS", "false").lower() == "true":
             options.add_argument("--headless")
             options.add_argument("--no-sandbox")
+            options.add_argument('--window-size=1920,1080')
             options.add_argument("--disable-dev-shm-usage")
         self.browser = webdriver.Chrome(options=options)
         self.browser.maximize_window()

--- a/oemr-selenium/login_tests.py
+++ b/oemr-selenium/login_tests.py
@@ -15,6 +15,7 @@ class TestWebsite_login:
         if os.environ.get('HEADLESS', 'false').lower() == 'true':
             options.add_argument("--headless")
             options.add_argument("--no-sandbox")
+            options.add_argument('--window-size=1920,1080')
             options.add_argument("--disable-dev-shm-usage")
 
         self.browser = webdriver.Chrome(options=options)

--- a/oemr-selenium/logout.py
+++ b/oemr-selenium/logout.py
@@ -16,8 +16,8 @@ class TestWebsite_logout:
         if os.environ.get('HEADLESS', 'false').lower() == 'true':
             options.add_argument("--headless")
             options.add_argument("--no-sandbox")
+            options.add_argument('--window-size=1920,1080')
             options.add_argument("--disable-dev-shm-usage")
-
         self.browser = webdriver.Chrome(options=options)
         self.browser.maximize_window()
         self.browser.implicitly_wait(10)

--- a/oemr-selenium/patient_search.py
+++ b/oemr-selenium/patient_search.py
@@ -17,6 +17,7 @@ class TestWebsite_patient_search:
         if os.environ.get('HEADLESS', 'false').lower() == 'true':
             options.add_argument("--headless")
             options.add_argument("--no-sandbox")
+            options.add_argument('--window-size=1920,1080')
             options.add_argument("--disable-dev-shm-usage")
 
         self.browser = webdriver.Chrome(options=options)
@@ -74,9 +75,6 @@ class TestWebsite_patient_search:
         assert success, f"Login failed for server {config.url}"
         wait_for_page_load(self.browser)
 
-        self.browser.find_element(By.XPATH, '//*[@id="mainBox"]/nav/button').click()
-        wait_for_page_load(self.browser)
-
         self.browser.find_element(By.XPATH, '//div[@class="menuLabel px-1" and text()="Finder"]').click()
         wait_for_page_load(self.browser)
 
@@ -101,9 +99,6 @@ class TestWebsite_patient_search:
     def test_search_not_found_patient_using_finder(self, config):
         success = login(self.browser, config.username, config.password, config.url, config.server_name)
         assert success, f"Login failed for server {config.url}"
-        wait_for_page_load(self.browser)
-
-        self.browser.find_element(By.XPATH, '//*[@id="mainBox"]/nav/button').click()
         wait_for_page_load(self.browser)
 
         self.browser.find_element(By.XPATH, '//div[@class="menuLabel px-1" and text()="Finder"]').click()

--- a/oemr-selenium/ssn_search.py
+++ b/oemr-selenium/ssn_search.py
@@ -17,6 +17,7 @@ class TestWebsite_patient_search:
         if os.environ.get('HEADLESS', 'false').lower() == 'true':
             options.add_argument("--headless")
             options.add_argument("--no-sandbox")
+            options.add_argument('--window-size=1920,1080')
             options.add_argument("--disable-dev-shm-usage")
 
         self.browser = webdriver.Chrome(options=options)

--- a/oemr-selenium/vitals.py
+++ b/oemr-selenium/vitals.py
@@ -1,4 +1,3 @@
-import time
 import pytest
 import os
 from selenium import webdriver
@@ -19,6 +18,7 @@ class TestWebsite_vitals:
         if os.environ.get('HEADLESS', 'false').lower() == 'true':
             options.add_argument("--headless")
             options.add_argument("--no-sandbox")
+            options.add_argument('--window-size=1920,1080')
             options.add_argument("--disable-dev-shm-usage")
 
         self.browser = webdriver.Chrome(options=options)
@@ -121,8 +121,8 @@ class TestWebsite_vitals:
                     EC.element_to_be_clickable((By.ID, "pastEncounters"))
                 )
                 pastEncounters.click()
-            except (NoSuchElementException, TimeoutException):
-                pass
+            except (NoSuchElementException, TimeoutException) as e:
+                print(e)
 
         wait_for_page_load(self.browser)
 
@@ -139,15 +139,7 @@ class TestWebsite_vitals:
         wait_for_page_load(self.browser)
 
         clinicalTab = self.browser.find_element(By.XPATH, '//*[@id="category_Clinical"]')
-        self.browser.execute_script("arguments[0].scrollIntoView({block: 'center'});", clinicalTab)
-        WebDriverWait(self.browser, 5).until(
-        EC.element_to_be_clickable((By.XPATH, '//*[@id="category_Clinical"]'))
-        )
-        try:
-            clinicalTab.click()
-        except Exception:
-            from selenium.webdriver.common.action_chains import ActionChains
-            ActionChains(self.browser).move_to_element(clinicalTab).click().perform()
+        clinicalTab.click()
         wait_for_page_load(self.browser)
 
         vitals = self.browser.find_element(By.XPATH, '//div[@id="navbarSupportedContent"]//a[contains(@onclick, "formname=vitals")]')

--- a/oemr-selenium/vitals.py
+++ b/oemr-selenium/vitals.py
@@ -139,9 +139,15 @@ class TestWebsite_vitals:
         wait_for_page_load(self.browser)
 
         clinicalTab = self.browser.find_element(By.XPATH, '//*[@id="category_Clinical"]')
-        self.browser.execute_script("arguments[0].scrollIntoView(true);", clinicalTab)
-        time.sleep(1)
-        clinicalTab.click()
+        self.browser.execute_script("arguments[0].scrollIntoView({block: 'center'});", clinicalTab)
+        WebDriverWait(self.browser, 5).until(
+        EC.element_to_be_clickable((By.XPATH, '//*[@id="category_Clinical"]'))
+        )
+        try:
+            clinicalTab.click()
+        except Exception:
+            from selenium.webdriver.common.action_chains import ActionChains
+            ActionChains(self.browser).move_to_element(clinicalTab).click().perform()
         wait_for_page_load(self.browser)
 
         vitals = self.browser.find_element(By.XPATH, '//div[@id="navbarSupportedContent"]//a[contains(@onclick, "formname=vitals")]')

--- a/oemr-selenium/vitals.py
+++ b/oemr-selenium/vitals.py
@@ -1,3 +1,4 @@
+import time
 import pytest
 import os
 from selenium import webdriver
@@ -138,6 +139,8 @@ class TestWebsite_vitals:
         wait_for_page_load(self.browser)
 
         clinicalTab = self.browser.find_element(By.XPATH, '//*[@id="category_Clinical"]')
+        self.browser.execute_script("arguments[0].scrollIntoView(true);", clinicalTab)
+        time.sleep(1)
         clinicalTab.click()
         wait_for_page_load(self.browser)
 


### PR DESCRIPTION
Resolves issue #65.

- Set a fixed window size for all Selenium tests to ensure consistent UI rendering in both headless and headed modes.
- Prevents navigation/menu element disappearance due to viewport width <800px.
- Updated all relevant test files to include the new window size setup.

Verified that previously failing tests now pass in both modes.
