### PR TITLE
refactor: centralize browser setup using shared fixture in test_utils.py

### DIFF
--- a/oemr-selenium/active_medication_check.py
+++ b/oemr-selenium/active_medication_check.py
@@ -13,19 +13,9 @@ import re
 
 class TestWebsite_vitals:
     @pytest.fixture(autouse=True)
-    def browser_setup_and_teardown(self):
-        options = Options()
-        if os.environ.get('HEADLESS', 'false').lower() == 'true':
-            options.add_argument("--headless")
-            options.add_argument("--no-sandbox")
-            options.add_argument("--disable-dev-shm-usage")
-
-        self.browser = webdriver.Chrome(options=options)
-        self.browser.maximize_window()
-        self.browser.implicitly_wait(10)
-        yield
-        self.browser.close()
-        self.browser.quit()
+    def setup_browser(self, browser_fixture):
+        # self.browser is set via shared browser_fixture in test_utils.py
+        pass
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_medications_are_present_on_patient_dashboard(self, config):

--- a/oemr-selenium/active_medication_check.py
+++ b/oemr-selenium/active_medication_check.py
@@ -13,9 +13,7 @@ import re
 
 class TestWebsite_vitals:
     @pytest.fixture(autouse=True)
-    def setup_browser(self, browser_fixture):
-        # self.browser is set via shared browser_fixture in test_utils.py
-        pass
+    def setup_browser(self): yield from browser_setup_and_teardown(self)
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_medications_are_present_on_patient_dashboard(self, config):

--- a/oemr-selenium/bp_value_check.py
+++ b/oemr-selenium/bp_value_check.py
@@ -9,9 +9,7 @@ from test_utils import *
 
 class TestBPValues:
     @pytest.fixture(autouse=True)
-    def setup_browser(self, browser_fixture):
-        # self.browser is set via shared browser_fixture in test_utils.py
-        pass
+    def setup_browser(self): yield from browser_setup_and_teardown(self)
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_bp_systolic_and_diastolic_present(self, config):

--- a/oemr-selenium/bp_value_check.py
+++ b/oemr-selenium/bp_value_check.py
@@ -9,17 +9,9 @@ from test_utils import *
 
 class TestBPValues:
     @pytest.fixture(autouse=True)
-    def setup_and_teardown(self):
-        options = Options()
-        if os.environ.get("HEADLESS", "false").lower() == "true":
-            options.add_argument("--headless")
-            options.add_argument("--no-sandbox")
-            options.add_argument("--disable-dev-shm-usage")
-        self.browser = webdriver.Chrome(options=options)
-        self.browser.maximize_window()
-        self.browser.implicitly_wait(10)
-        yield
-        self.browser.quit()
+    def setup_browser(self, browser_fixture):
+        # self.browser is set via shared browser_fixture in test_utils.py
+        pass
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_bp_systolic_and_diastolic_present(self, config):

--- a/oemr-selenium/cdr_rule.py
+++ b/oemr-selenium/cdr_rule.py
@@ -12,20 +12,11 @@ from webdriver_manager.chrome import ChromeDriverManager
 from test_utils import *
 
 class TestWebsite_cdr_rule:
-    @pytest.fixture(autouse=True)
-    def browser_setup_and_teardown(self):
-        options = Options()
-        if os.environ.get('HEADLESS', 'false').lower() == 'true':
-            options.add_argument("--headless")
-            options.add_argument("--no-sandbox")
-            options.add_argument("--disable-dev-shm-usage")
 
-        self.browser = webdriver.Chrome(options=options)
-        self.browser.maximize_window()
-        self.browser.implicitly_wait(10)
-        yield
-        self.browser.close()
-        self.browser.quit()
+    @pytest.fixture(autouse=True)
+    def setup_browser(self, browser_fixture):
+        # self.browser is set via shared browser_fixture in test_utils.py
+        pass
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_cdr_rule_validation(self, config):

--- a/oemr-selenium/cdr_rule.py
+++ b/oemr-selenium/cdr_rule.py
@@ -14,9 +14,7 @@ from test_utils import *
 class TestWebsite_cdr_rule:
 
     @pytest.fixture(autouse=True)
-    def setup_browser(self, browser_fixture):
-        # self.browser is set via shared browser_fixture in test_utils.py
-        pass
+    def setup_browser(self): yield from browser_setup_and_teardown(self)
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_cdr_rule_validation(self, config):

--- a/oemr-selenium/clinical_notes_search.py
+++ b/oemr-selenium/clinical_notes_search.py
@@ -13,19 +13,7 @@ import re
 
 class TestWebsite_vitals:
     @pytest.fixture(autouse=True)
-    def browser_setup_and_teardown(self):
-        options = Options()
-        if os.environ.get('HEADLESS', 'false').lower() == 'true':
-            options.add_argument("--headless")
-            options.add_argument("--no-sandbox")
-            options.add_argument("--disable-dev-shm-usage")
-
-        self.browser = webdriver.Chrome(options=options)
-        self.browser.maximize_window()
-        self.browser.implicitly_wait(10)
-        yield
-        self.browser.close()
-        self.browser.quit()
+    def setup_browser(self): yield from browser_setup_and_teardown(self)
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_clinical_notes_is_present_in_encounters(self, config):

--- a/oemr-selenium/code_check.py
+++ b/oemr-selenium/code_check.py
@@ -11,19 +11,9 @@ from test_utils import *
 
 class TestWebsite_cdr_code_check:
     @pytest.fixture(autouse=True)
-    def browser_setup_and_teardown(self):
-        options = Options()
-        if os.environ.get('HEADLESS', 'false').lower() == 'true':
-            options.add_argument("--headless")
-            options.add_argument("--no-sandbox")
-            options.add_argument("--disable-dev-shm-usage")
-
-        self.browser = webdriver.Chrome(options=options)
-        self.browser.maximize_window()
-        self.browser.implicitly_wait(10)
-        yield
-        self.browser.close()
-        self.browser.quit()
+    def setup_browser(self, browser_fixture):
+        # self.browser is set via shared browser_fixture in test_utils.py
+        pass
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_code_list_validation(self, config):

--- a/oemr-selenium/code_check.py
+++ b/oemr-selenium/code_check.py
@@ -11,9 +11,7 @@ from test_utils import *
 
 class TestWebsite_cdr_code_check:
     @pytest.fixture(autouse=True)
-    def setup_browser(self, browser_fixture):
-        # self.browser is set via shared browser_fixture in test_utils.py
-        pass
+    def setup_browser(self): yield from browser_setup_and_teardown(self)
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_code_list_validation(self, config):

--- a/oemr-selenium/facilities_check.py
+++ b/oemr-selenium/facilities_check.py
@@ -9,9 +9,7 @@ from test_utils import *
 
 class TestFacilityList:
     @pytest.fixture(autouse=True)
-    def setup_browser(self, browser_fixture):
-        # self.browser is set via shared browser_fixture in test_utils.py
-        pass
+    def setup_browser(self): yield from browser_setup_and_teardown(self)
 
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)

--- a/oemr-selenium/facilities_check.py
+++ b/oemr-selenium/facilities_check.py
@@ -9,17 +9,10 @@ from test_utils import *
 
 class TestFacilityList:
     @pytest.fixture(autouse=True)
-    def setup_and_teardown(self):
-        options = Options()
-        if os.environ.get("HEADLESS", "false").lower() == "true":
-            options.add_argument("--headless")
-            options.add_argument("--no-sandbox")
-            options.add_argument("--disable-dev-shm-usage")
-        self.browser = webdriver.Chrome(options=options)
-        self.browser.maximize_window()
-        self.browser.implicitly_wait(10)
-        yield
-        self.browser.quit()
+    def setup_browser(self, browser_fixture):
+        # self.browser is set via shared browser_fixture in test_utils.py
+        pass
+
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_facility_list_displayed_correctly(self, config):

--- a/oemr-selenium/login_tests.py
+++ b/oemr-selenium/login_tests.py
@@ -10,19 +10,9 @@ from test_utils import *
 
 class TestWebsite_login:
     @pytest.fixture(autouse=True)
-    def login_page_setup(self):
-        options = Options()
-        if os.environ.get('HEADLESS', 'false').lower() == 'true':
-            options.add_argument("--headless")
-            options.add_argument("--no-sandbox")
-            options.add_argument("--disable-dev-shm-usage")
-
-        self.browser = webdriver.Chrome(options=options)
-        self.browser.maximize_window()
-        self.browser.implicitly_wait(10)
-        yield
-        self.browser.close()
-        self.browser.quit()
+    def setup_browser(self, browser_fixture):
+        # self.browser is set via shared browser_fixture in test_utils.py
+        pass
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_valid_admin_and_user_credentials(self, config):

--- a/oemr-selenium/login_tests.py
+++ b/oemr-selenium/login_tests.py
@@ -10,9 +10,7 @@ from test_utils import *
 
 class TestWebsite_login:
     @pytest.fixture(autouse=True)
-    def setup_browser(self, browser_fixture):
-        # self.browser is set via shared browser_fixture in test_utils.py
-        pass
+    def setup_browser(self): yield from browser_setup_and_teardown(self)
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_valid_admin_and_user_credentials(self, config):

--- a/oemr-selenium/logout.py
+++ b/oemr-selenium/logout.py
@@ -11,9 +11,7 @@ from test_utils import *
 
 class TestWebsite_logout:
     @pytest.fixture(autouse=True)
-    def setup_browser(self, browser_fixture):
-        # self.browser is set via shared browser_fixture in test_utils.py
-        pass
+    def setup_browser(self): yield from browser_setup_and_teardown(self)
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_logout(self, config):

--- a/oemr-selenium/logout.py
+++ b/oemr-selenium/logout.py
@@ -11,20 +11,9 @@ from test_utils import *
 
 class TestWebsite_logout:
     @pytest.fixture(autouse=True)
-    def browser_setup_and_teardown(self):
-        options = Options()
-        if os.environ.get('HEADLESS', 'false').lower() == 'true':
-            options.add_argument("--headless")
-            options.add_argument("--no-sandbox")
-            options.add_argument("--disable-dev-shm-usage")
-
-        self.browser = webdriver.Chrome(options=options)
-        self.browser.maximize_window()
-        self.browser.implicitly_wait(10)
-
-        yield
-        self.browser.close()
-        self.browser.quit()
+    def setup_browser(self, browser_fixture):
+        # self.browser is set via shared browser_fixture in test_utils.py
+        pass
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_logout(self, config):

--- a/oemr-selenium/patient_search.py
+++ b/oemr-selenium/patient_search.py
@@ -12,9 +12,7 @@ import re
 
 class TestWebsite_patient_search:
     @pytest.fixture(autouse=True)
-    def setup_browser(self, browser_fixture):
-        # self.browser is set via shared browser_fixture in test_utils.py
-        pass
+    def setup_browser(self): yield from browser_setup_and_teardown(self)
 
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)

--- a/oemr-selenium/patient_search.py
+++ b/oemr-selenium/patient_search.py
@@ -12,17 +12,10 @@ import re
 
 class TestWebsite_patient_search:
     @pytest.fixture(autouse=True)
-    def browser_setup_and_teardown(self):
-        options = Options()
-        if os.environ.get('HEADLESS', 'false').lower() == 'true':
-            options.add_argument("--headless")
-            options.add_argument("--no-sandbox")
-            options.add_argument("--disable-dev-shm-usage")
+    def setup_browser(self, browser_fixture):
+        # self.browser is set via shared browser_fixture in test_utils.py
+        pass
 
-        self.browser = webdriver.Chrome(options=options)
-        self.browser.implicitly_wait(10)
-        yield
-        self.browser.quit()
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_search_found_patient_using_search_bar(self, config):
@@ -74,8 +67,6 @@ class TestWebsite_patient_search:
         assert success, f"Login failed for server {config.url}"
         wait_for_page_load(self.browser)
 
-        self.browser.find_element(By.XPATH, '//*[@id="mainBox"]/nav/button').click()
-        wait_for_page_load(self.browser)
 
         self.browser.find_element(By.XPATH, '//div[@class="menuLabel px-1" and text()="Finder"]').click()
         wait_for_page_load(self.browser)
@@ -101,9 +92,6 @@ class TestWebsite_patient_search:
     def test_search_not_found_patient_using_finder(self, config):
         success = login(self.browser, config.username, config.password, config.url, config.server_name)
         assert success, f"Login failed for server {config.url}"
-        wait_for_page_load(self.browser)
-
-        self.browser.find_element(By.XPATH, '//*[@id="mainBox"]/nav/button').click()
         wait_for_page_load(self.browser)
 
         self.browser.find_element(By.XPATH, '//div[@class="menuLabel px-1" and text()="Finder"]').click()

--- a/oemr-selenium/ssn_search.py
+++ b/oemr-selenium/ssn_search.py
@@ -12,9 +12,7 @@ import re
 
 class TestWebsite_patient_search:
     @pytest.fixture(autouse=True)
-    def setup_browser(self, browser_fixture):
-        # self.browser is set via shared browser_fixture in test_utils.py
-        pass
+    def setup_browser(self): yield from browser_setup_and_teardown(self)
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_search_found_ssn_using_search_bar(self, config):

--- a/oemr-selenium/ssn_search.py
+++ b/oemr-selenium/ssn_search.py
@@ -12,17 +12,9 @@ import re
 
 class TestWebsite_patient_search:
     @pytest.fixture(autouse=True)
-    def browser_setup_and_teardown(self):
-        options = Options()
-        if os.environ.get('HEADLESS', 'false').lower() == 'true':
-            options.add_argument("--headless")
-            options.add_argument("--no-sandbox")
-            options.add_argument("--disable-dev-shm-usage")
-
-        self.browser = webdriver.Chrome(options=options)
-        self.browser.implicitly_wait(10)
-        yield
-        self.browser.quit()
+    def setup_browser(self, browser_fixture):
+        # self.browser is set via shared browser_fixture in test_utils.py
+        pass
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_search_found_ssn_using_search_bar(self, config):

--- a/oemr-selenium/test.py
+++ b/oemr-selenium/test.py
@@ -13,31 +13,17 @@ class TestWebsite:
     # 3. Test report will be created in reports/ directory
 
     @pytest.fixture(autouse=True)
-    def browser_setup_and_teardown(self):
-        options = Options()
-        # options.add_experimental_option("detach", True)
-
-        self.browser = webdriver.Chrome(options=options)
-
-        self.browser.maximize_window()
-        self.browser.implicitly_wait(10)
+    def setup_browser(self, browser_fixture):
+        # Shared setup from test_utils.py – sets self.browser
         self.browser.get("https://in-info-web18.luddy.indianapolis.iu.edu/interface/login/login.php?site=default")
-
-        """this test checks login functionality"""
         self.browser.find_element(By.ID, 'authUser').send_keys(get_user())
         self.browser.find_element(By.ID, "clearPass").send_keys(get_pass())
         self.browser.find_element(By.ID, "login-button").submit()
 
         assert "https://in-info-web18.luddy.indianapolis.iu.edu/interface/main/tabs/main.php?" in self.browser.current_url
 
-        # Close all open tabs first
         for tabClose in self.browser.find_elements(By.CSS_SELECTOR, 'span[class="fa fa-fw fa-xs fa-times"]'):
             tabClose.click()
-
-        yield
-
-        self.browser.close()
-        self.browser.quit()
 
     def test_search_found_patient(self):
         """this test checks any box search functionality"""

--- a/oemr-selenium/test.py
+++ b/oemr-selenium/test.py
@@ -13,8 +13,10 @@ class TestWebsite:
     # 3. Test report will be created in reports/ directory
 
     @pytest.fixture(autouse=True)
-    def setup_browser(self, browser_fixture):
-        # Shared setup from test_utils.py – sets self.browser
+    def setup_browser(self):
+        yield from browser_setup_and_teardown(self)
+
+        # Now that browser is ready, do login
         self.browser.get("https://in-info-web18.luddy.indianapolis.iu.edu/interface/login/login.php?site=default")
         self.browser.find_element(By.ID, 'authUser').send_keys(get_user())
         self.browser.find_element(By.ID, "clearPass").send_keys(get_pass())

--- a/oemr-selenium/test_utils.py
+++ b/oemr-selenium/test_utils.py
@@ -3,6 +3,11 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from dataclasses import dataclass
 from typing import List
+import os
+import pytest
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+
 
 @dataclass
 class ServerConfig:
@@ -78,3 +83,21 @@ def wait_for_page_load(driver, timeout=30):
     WebDriverWait(driver, timeout).until(
         lambda d: d.execute_script('return typeof jQuery == "undefined" || jQuery.active == 0')
     )
+
+def init_browser():
+    options = Options()
+    if os.environ.get('HEADLESS', 'false').lower() == 'true':
+        options.add_argument("--headless")
+        options.add_argument("--no-sandbox")
+        options.add_argument("--disable-dev-shm-usage")
+    browser = webdriver.Chrome(options=options)
+    browser.maximize_window()
+    browser.implicitly_wait(10)
+    return browser
+
+@pytest.fixture
+def browser_fixture(request):
+    browser = init_browser()
+    request.instance.browser = browser
+    yield
+    browser.quit()

--- a/oemr-selenium/test_utils.py
+++ b/oemr-selenium/test_utils.py
@@ -84,21 +84,18 @@ def wait_for_page_load(driver, timeout=30):
         lambda d: d.execute_script('return typeof jQuery == "undefined" || jQuery.active == 0')
     )
 
-def init_browser():
+def browser_setup_and_teardown(test_instance):
     options = Options()
     if os.environ.get('HEADLESS', 'false').lower() == 'true':
         options.add_argument("--headless")
         options.add_argument("--no-sandbox")
         options.add_argument('--window-size=1920,1080')
         options.add_argument("--disable-dev-shm-usage")
+
     browser = webdriver.Chrome(options=options)
     browser.maximize_window()
     browser.implicitly_wait(10)
-    return browser
-
-@pytest.fixture
-def browser_fixture(request):
-    browser = init_browser()
-    request.instance.browser = browser
+    test_instance.browser = browser
     yield
+    browser.close()
     browser.quit()

--- a/oemr-selenium/test_utils.py
+++ b/oemr-selenium/test_utils.py
@@ -89,6 +89,7 @@ def init_browser():
     if os.environ.get('HEADLESS', 'false').lower() == 'true':
         options.add_argument("--headless")
         options.add_argument("--no-sandbox")
+        options.add_argument('--window-size=1920,1080')
         options.add_argument("--disable-dev-shm-usage")
     browser = webdriver.Chrome(options=options)
     browser.maximize_window()

--- a/oemr-selenium/vitals.py
+++ b/oemr-selenium/vitals.py
@@ -15,9 +15,7 @@ from selenium.common.exceptions import TimeoutException
 class TestWebsite_vitals:
 
     @pytest.fixture(autouse=True)
-    def setup_browser(self, browser_fixture):
-        # Shared setup from test_utils.py — provides self.browser
-        pass
+    def setup_browser(self): yield from browser_setup_and_teardown(self)
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_vitals_is_present_on_patient_dashboard(self, config):
@@ -113,7 +111,7 @@ class TestWebsite_vitals:
                 )
                 pastEncounters.click()
             except (NoSuchElementException, TimeoutException) as e:
-                print("Modal not found or timed out")
+                logging.error("Modal not found or timed out")
 
         wait_for_page_load(self.browser)
 

--- a/oemr-selenium/vitals.py
+++ b/oemr-selenium/vitals.py
@@ -112,8 +112,8 @@ class TestWebsite_vitals:
                     EC.element_to_be_clickable((By.ID, "pastEncounters"))
                 )
                 pastEncounters.click()
-            except (NoSuchElementException, TimeoutException):
-                pass
+            except (NoSuchElementException, TimeoutException) as e:
+                print("Modal not found or timed out")
 
         wait_for_page_load(self.browser)
 

--- a/oemr-selenium/vitals.py
+++ b/oemr-selenium/vitals.py
@@ -12,20 +12,12 @@ from test_utils import *
 import re
 
 class TestWebsite_vitals:
-    @pytest.fixture(autouse=True)
-    def browser_setup_and_teardown(self):
-        options = Options()
-        if os.environ.get('HEADLESS', 'false').lower() == 'true':
-            options.add_argument("--headless")
-            options.add_argument("--no-sandbox")
-            options.add_argument("--disable-dev-shm-usage")
 
-        self.browser = webdriver.Chrome(options=options)
-        self.browser.maximize_window()
-        self.browser.implicitly_wait(10)
-        yield
-        self.browser.close()
-        self.browser.quit()
+    @pytest.fixture(autouse=True)
+    def setup_browser(self, browser_fixture):
+        # Shared setup from test_utils.py — provides self.browser
+        pass
+
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_vitals_is_present_on_patient_dashboard(self, config):

--- a/oemr-selenium/vitals.py
+++ b/oemr-selenium/vitals.py
@@ -10,6 +10,7 @@ from selenium.webdriver.common.alert import Alert
 from webdriver_manager.chrome import ChromeDriverManager
 from test_utils import *
 import re
+from selenium.common.exceptions import TimeoutException
 
 class TestWebsite_vitals:
 
@@ -17,7 +18,6 @@ class TestWebsite_vitals:
     def setup_browser(self, browser_fixture):
         # Shared setup from test_utils.py — provides self.browser
         pass
-
 
     @pytest.mark.parametrize("config", read_configurations_from_file("secret.json"), ids=sanitize_test_name)
     def test_vitals_is_present_on_patient_dashboard(self, config):


### PR DESCRIPTION
Refactored all test files to use a shared browser fixture from test_utils.py. Removed repeated Chrome setup code and kept self.browser working the same. No test logic changed — just cleaned up setup to make it easier to maintain.

